### PR TITLE
Adds configuration option g:journal_extension

### DIFF
--- a/doc/journal.txt
+++ b/doc/journal.txt
@@ -36,6 +36,9 @@ g:journal_directory                                      *g:journal_directory*
 g:journal_encrypted                                      *g:journal_encrypted*
     Encryption is disabled by default. To enable, set this variable.
 
+g:journal_extension                                      *g:journal_extension*
+    The filename extension (plain default: txt, encrypted default: asc).
+
 g:GPGDefaultRecipients
     If set, these recipients are used as defaults when no other recipient is
     defined. This variable is a Vim list. Default is unset.

--- a/plugin/journal.vim
+++ b/plugin/journal.vim
@@ -17,6 +17,10 @@ if !exists("g:journal_directory")
     let g:journal_directory = '~/Journal'
 endif
 
+if !exists("g:journal_extension")
+    let g:journal_extension = exists('g:journal_encrypted') ? 'asc' : 'txt'
+endif
+
 command -bar JournalToggle :call s:JournalToggle()
 
 function! s:SID() "{{{1
@@ -53,8 +57,7 @@ function! s:FormatDate(year, month, day) "{{{1
 endfunction
 
 function! s:JournalFilename(year, month, day) "{{{1
-    let ext = exists('g:journal_encrypted') ? 'asc' : 'txt'
-    return expand(g:journal_directory).'/'.s:FormatDate(a:year, a:month, a:day).'.'.ext
+    return expand(g:journal_directory).'/'.s:FormatDate(a:year, a:month, a:day).'.'.g:journal_extension
 endfunction
 
 function! s:JournalCalendarAction(day, month, year, week, dir) "{{{1


### PR DESCRIPTION
Defaults to "txt" for plaintext and "asc" for ciphertext. Setting 
this option will use the given extension regardless of whether 
g:journal_encrypted is set.
